### PR TITLE
Added configuration to switch between legacy and mode B

### DIFF
--- a/camera_firewire.orogen
+++ b/camera_firewire.orogen
@@ -24,6 +24,12 @@ task_context 'CameraTask' do
         doc 'hdr kneepoint2 voltage level 1 [0..255]'
     property('hdr_voltage_4', 'int', 0).
         doc 'hdr kneepoint2 voltage level 2 [0..255]'
+    
+    # Firewire mode settings
+    property('operation_mode', 'char').
+        doc 'Set the firewire operation mode, possible values are A and B'
+    property('isochronous_speed', 'int', 400).
+        doc 'Set the firewire isochronous speed'
 
     operation('setHDRValues').
         returns('bool').

--- a/tasks/CameraTask.cpp
+++ b/tasks/CameraTask.cpp
@@ -130,16 +130,26 @@ bool CameraTask::configureHook()
     }
     if( !opened )
     {
-	RTT::log(RTT::Error) << "Did not find camera with id " << cam_id <<  RTT::endlog();
-	return false;
+	    RTT::log(RTT::Error) << "Did not find camera with id " << cam_id <<  RTT::endlog();
+	    return false;
     }
     
     cam_interface = camera;
     
-    if(!camera->setAttrib(int_attrib::IsoSpeed, 400))
+    if(!camera->setAttrib(int_attrib::OperationMode, _operation_mode.value()))
     {
-	RTT::log(RTT::Error) << "Failed to set IsoSpeed for camera " << cam_id <<  RTT::endlog();
-	return false;
+	    RTT::log(RTT::Error) << "Failed to set OperationMode for camera " << cam_id <<  RTT::endlog();
+	    return false;
+    }
+    else
+    {
+        std::cout << "OK" << std::endl;
+    }
+    
+    if(!camera->setAttrib(int_attrib::IsoSpeed, _isochronous_speed.value()))
+    {
+	    RTT::log(RTT::Error) << "Failed to set IsoSpeed for camera " << cam_id <<  RTT::endlog();
+	    return false;
     }
     
     if(camera->isAttribAvail(int_attrib::HDRValue))

--- a/tasks/CameraTask.cpp
+++ b/tasks/CameraTask.cpp
@@ -141,10 +141,6 @@ bool CameraTask::configureHook()
 	    RTT::log(RTT::Error) << "Failed to set OperationMode for camera " << cam_id <<  RTT::endlog();
 	    return false;
     }
-    else
-    {
-        std::cout << "OK" << std::endl;
-    }
     
     if(!camera->setAttrib(int_attrib::IsoSpeed, _isochronous_speed.value()))
     {


### PR DESCRIPTION
Added properties to select between legacy and mode B for FireWire via the configuration.

Depends on these pulls (in order):
* https://github.com/rock-drivers/drivers-camera_interface/pull/1
* https://github.com/rock-drivers/drivers-camera_firewire/pull/1