### PR TITLE
Remove unused OpenCV dependency

### DIFF
--- a/camera_firewire.orogen
+++ b/camera_firewire.orogen
@@ -1,6 +1,5 @@
 name 'camera_firewire'
 
-using_library "opencv"
 using_library "camera_firewire"
 using_library "camera_interface"
 using_task_library "camera_base"

--- a/manifest.xml
+++ b/manifest.xml
@@ -7,7 +7,6 @@
   <url>http://</url>
   <logo>http://</logo>
   <depend package="base/types" />
-  <depend package="opencv" />
   <depend package="drivers/orogen/camera_base" />
   <depend package="drivers/camera_firewire"/>
   <depend package="drivers/aggregator"/>


### PR DESCRIPTION
As far as I can see, the package does not actually use OpenCV anywhere. By removing the dependency we don't have to handle OpenCV version problems in this package.